### PR TITLE
Simplified and renforced type guards.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,22 +4,25 @@ module.exports={
 
         try
         {
-            if (typeof hours === 'string') { 
+            if (typeof hours !== 'number') { 
                 throw new Error("hours should be integer value");
             }
-            if (typeof minutes === 'string') {
+            if (typeof minutes !== 'number') {
                 throw new Error("minutes should be integer value");
             }
-            if (typeof seconds === 'string') {
+            if (typeof seconds !== 'number') {
                 throw new Error("seconds should be integer value");
             }
-            if(hours>12 || hours<1 || hours===undefined){
+            if (typeof amorpm !== 'string') {
+                throw new Error("amorpm should be string");
+	    }
+            if(hours>12 || hours<1){
                 throw new Error("hours should be between or equal to 1 and 12");
             }
-            if(minutes>=60 || minutes<0 || minutes===undefined){
+            if(minutes>=60 || minutes<0){
                 throw new Error("minutes should be between 0 and 60");
             }
-            if(seconds>=60 || seconds<0 || seconds===undefined){
+            if(seconds>=60 || seconds<0){
                 throw new Error("seconds should be between 0 and 60");
             }
             if(amorpm.toUpperCase()!=="AM" && amorpm.toUpperCase()!=="PM"){
@@ -52,22 +55,22 @@ module.exports={
 
         try
         {
-            if (typeof hours === 'string') { 
+            if (typeof hours !== 'number') { 
                 throw new Error("hours should be integer value");
             }
-            if (typeof minutes === 'string') {
+            if (typeof minutes !== 'number') {
                 throw new Error("minutes should be integer value");
             }
-            if (typeof seconds === 'string') {
+            if (typeof seconds !== 'number') {
                 throw new Error("seconds should be integer value");
             }
-            if(hours>23 || hours<0 || hours===undefined){
+            if(hours>23 || hours<0){
                 throw new Error("hours should be between 0 and 24");
             }
-            if(minutes>=60 || minutes<0  || minutes===undefined){
+            if(minutes>=60 || minutes<0){
                 throw new Error("minutes should be between 0 and 60");
             }
-            if(seconds>=60 || seconds<0  || seconds===undefined){
+            if(seconds>=60 || seconds<0){
                 throw new Error("seconds should be between 0 and 60");
             }
         }


### PR DESCRIPTION
With this fix:
 - `hours`, `minutes` and `seconds` must be numbers (without this fix they could have been objects, functions and more)
 - `amorpm` must be string (without this fix, if we passed a number as the `amorpm` parameter, the program would have complained about the method `toUpperCase`  since it doesn't exist on such type)